### PR TITLE
feat: added bepinex checking and installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "clap",
  "directories",
  "reqwest",
+ "serde_json",
  "steamlocate",
  "tempfile",
  "tokio",
@@ -1500,18 +1501,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1520,14 +1531,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 reqwest = { version = "0.12.23", features = ["json", "blocking"] }
 zip = "5.1.1"
 tokio = { version = "1", features = ["full"] }
+serde_json = "1.0.145"
 
 anyhow = "1"
 directories = "6.0.0"

--- a/src/bepinex_handler.rs
+++ b/src/bepinex_handler.rs
@@ -1,0 +1,110 @@
+use crate::bepinex_provider::{
+    BepinexProvider, LinuxBepinexProvider, MacOSBepinexProvider, UnsupportedBepinexProvider,
+    WindowsBepinexProvider,
+};
+use std::{error::Error, io::stdin, path::PathBuf};
+
+/// Enums for OS detection
+enum OS {
+    Windows,
+    Linux,
+    MacOs,
+    Unsupported,
+}
+
+pub struct BepinexHandler {
+    provider: Box<dyn BepinexProvider>,
+}
+
+impl BepinexHandler {
+    pub fn from_os(game_path: PathBuf, os: &str) -> Self {
+        let current_os: OS = match os {
+            "windows" => OS::Windows,
+            "linux" => OS::Linux,
+            "macos" => OS::MacOs,
+            _ => OS::Unsupported,
+        };
+
+        let provider: Box<dyn BepinexProvider> = match current_os {
+            OS::Windows => Box::new(WindowsBepinexProvider { game_path }),
+            OS::Linux => Box::new(LinuxBepinexProvider { game_path }),
+            OS::MacOs => Box::new(MacOSBepinexProvider { game_path }),
+            OS::Unsupported => Box::new(UnsupportedBepinexProvider),
+        };
+
+        Self { provider }
+    }
+
+    pub fn new(game_path: PathBuf) -> Self {
+        Self::from_os(game_path, std::env::consts::OS)
+    }
+
+    /// Dynamic dispatch of the correct method
+    pub fn check_installation(&self) -> Result<bool, String> {
+        self.provider.check_installation()
+    }
+
+    pub fn install(&self) -> Result<(), Box<dyn Error>> {
+        // Ask to skip or overwrite installation if already present
+        if self.check_installation()? {
+            println!("BepInEx is already installed, do you want to reinstall it? [y/N]");
+            let mut input = String::new();
+            stdin()
+                .read_line(&mut input)
+                .expect("Failed to read the input");
+
+            if input == "y\n" || input == "Y\n" {
+                return self.provider.install();
+            } else {
+                return Err("Installation aborted by the user".into());
+            }
+        }
+        self.provider.install()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_bepinex_handler_linux() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let handler = BepinexHandler::from_os(game_path.clone(), "linux");
+        assert!(handler.check_installation().is_ok());
+        assert!(handler.install().is_ok());
+    }
+
+    #[test]
+    fn test_bepinex_handler_windows() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let handler = BepinexHandler::from_os(game_path.clone(), "windows");
+        assert!(handler.check_installation().is_ok());
+        assert!(handler.install().is_ok());
+    }
+
+    #[test]
+    fn test_bepinex_handler_macos() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let handler = BepinexHandler::from_os(game_path.clone(), "macos");
+        assert!(handler.check_installation().is_ok());
+        assert!(handler.install().is_ok());
+    }
+
+    #[test]
+    fn test_bepinex_handler_unknown() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let handler = BepinexHandler::from_os(game_path.clone(), "freebsd");
+        assert!(handler.check_installation().is_err());
+        assert!(handler.install().is_err());
+    }
+}

--- a/src/bepinex_provider.rs
+++ b/src/bepinex_provider.rs
@@ -1,0 +1,368 @@
+use reqwest::blocking::{Client, get};
+use reqwest::header::USER_AGENT;
+use serde_json::Value;
+use std::error::Error;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use zip::read::ZipArchive;
+
+enum OS {
+    Windows,
+    Linux,
+    MacOs,
+}
+
+/// Abstract provider interface to allow different implementations for different operating systems
+pub trait BepinexProvider {
+    ///Check if all necessary directories, subdirectories and files at the game's root directory
+    ///exist
+    fn check_installation(&self) -> Result<bool, String>;
+
+    ///Download BepInEx and extract it in the game's directory
+    fn install(&self) -> Result<(), Box<dyn Error>>;
+}
+
+pub struct LinuxBepinexProvider {
+    pub game_path: PathBuf,
+}
+
+impl BepinexProvider for LinuxBepinexProvider {
+    fn check_installation(&self) -> Result<bool, String> {
+        let bepinex_dir = self.game_path.join("BepInEx");
+        let bepinex_core_dir = bepinex_dir.join("core");
+        let root_files = [
+            self.game_path.join("libdoorstop.so"),
+            self.game_path.join("run_bepinex.sh"),
+            self.game_path.join(".doorstop_version"),
+            self.game_path.join("changelog.txt"),
+        ];
+
+        let res = bepinex_dir.exists()
+            && bepinex_dir.is_dir()
+            && bepinex_core_dir.exists()
+            && bepinex_core_dir.is_dir()
+            && root_files.iter().all(|path| path.exists());
+
+        Ok(res)
+    }
+
+    fn install(&self) -> Result<(), Box<dyn Error>> {
+        install_bepinex_latest(OS::Linux, &self.game_path)?;
+
+        //Update the launch script according to the BepInEx installation docs
+        let game_executable_name = "Hollow Knight Silksong";
+        update_launch_script(&self.game_path, game_executable_name)
+    }
+}
+
+pub struct WindowsBepinexProvider {
+    pub game_path: PathBuf,
+}
+
+impl BepinexProvider for WindowsBepinexProvider {
+    fn check_installation(&self) -> Result<bool, String> {
+        let bepinex_dir = self.game_path.join("BepInEx");
+        let bepinex_core_dir = bepinex_dir.join("core");
+        let root_files = [
+            self.game_path.join("doorstop_config.ini"),
+            self.game_path.join("winhttp.dll"),
+            self.game_path.join(".doorstop_version"),
+            self.game_path.join("changelog.txt"),
+        ];
+
+        let res = bepinex_dir.exists()
+            && bepinex_dir.is_dir()
+            && bepinex_core_dir.exists()
+            && bepinex_core_dir.is_dir()
+            && root_files.iter().all(|path| path.exists());
+
+        Ok(res)
+    }
+
+    fn install(&self) -> Result<(), Box<dyn Error>> {
+        install_bepinex_latest(OS::Windows, &self.game_path)
+    }
+}
+
+pub struct MacOSBepinexProvider {
+    pub game_path: PathBuf,
+}
+
+impl BepinexProvider for MacOSBepinexProvider {
+    fn check_installation(&self) -> Result<bool, String> {
+        let bepinex_dir = self.game_path.join("BepInEx");
+        let bepinex_core_dir = bepinex_dir.join("core");
+        let root_files = [
+            self.game_path.join("libdoorstop.dylib"),
+            self.game_path.join("run_bepinex.sh"),
+            self.game_path.join(".doorstop_version"),
+            self.game_path.join("changelog.txt"),
+        ];
+
+        let res = bepinex_dir.exists()
+            && bepinex_dir.is_dir()
+            && bepinex_core_dir.exists()
+            && bepinex_core_dir.is_dir()
+            && root_files.iter().all(|path| path.exists());
+
+        Ok(res)
+    }
+
+    fn install(&self) -> Result<(), Box<dyn Error>> {
+        install_bepinex_latest(OS::MacOs, &self.game_path)?;
+
+        //Update the launch script according to the BepInEx installation docs
+        let game_executable_name = "Hollow Knight Silksong.app";
+        update_launch_script(&self.game_path, game_executable_name)
+    }
+}
+
+pub struct UnsupportedBepinexProvider;
+
+impl BepinexProvider for UnsupportedBepinexProvider {
+    fn check_installation(&self) -> Result<bool, String> {
+        Err("The current operating system is not supported!".into())
+    }
+
+    fn install(&self) -> Result<(), Box<dyn Error>> {
+        Err("The current operating system is not supported!".into())
+    }
+}
+
+/// Check for the latest release, download the zip for the specified platform and extract it in the
+/// specified game directory
+fn install_bepinex_latest(platform: OS, game_path: &Path) -> Result<(), Box<dyn Error>> {
+    let repo_author = "BepInEx";
+    let repo_name = "BepInEx";
+    let github_latest_url = "https://api.github.com/repos/BepInEx/BepInEx/releases/latest";
+
+    // Get the latest release tag
+    println!("Fetching the latest release...");
+    let client = Client::new();
+    let response = client
+        .get(github_latest_url)
+        .header(USER_AGENT, "Abyss/0.1") // Github requires this
+        .send()?;
+
+    let data: Value = response.json()?;
+
+    let tag;
+    match data.get("tag_name") {
+        Some(value) => {
+            tag = value.to_string().trim_matches('"').to_string();
+            println!("Found the latest version {}", tag);
+        }
+        None => return Err("Could not find the latest release of BepInEx".into()),
+    };
+
+    // Build the download url depending on the platform
+    let release_url = build_release_url(repo_author, repo_name, &tag, platform);
+    if release_url.is_empty() {
+        return Err("Unsupported platform for the github download!".into());
+    }
+
+    // Download of the zipped file
+    println!("Downloading {}", release_url);
+    let download_response = get(release_url)?;
+    let body = download_response.bytes()?;
+
+    // Store the file
+    let temp_file = game_path.join("downloaded.zip");
+    let mut file = File::create(&temp_file)?;
+    file.write_all(&body)?;
+
+    // Extraction
+    println!("Extracting...");
+    let file = File::open(&temp_file)?;
+    let mut archive = ZipArchive::new(file)?;
+
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        let outpath = game_path.join(file.name());
+
+        if file.is_dir() {
+            fs::create_dir_all(outpath)?;
+        } else {
+            if let Some(parent) = outpath.parent() {
+                if !parent.exists() {
+                    fs::create_dir_all(parent)?;
+                }
+            }
+            let mut out_file = File::create(outpath)?;
+            std::io::copy(&mut file, &mut out_file)?;
+        }
+    }
+
+    // Clean up
+    println!("Cleaning up...");
+    fs::remove_file(temp_file)?;
+
+    Ok(())
+}
+
+fn build_release_url(author: &str, repo: &str, tag: &str, platform: OS) -> String {
+    match platform {
+        OS::Windows => {
+            format!(
+                "https://github.com/{}/{}/releases/download/{}/BepInEx_{}_x64_{}.zip",
+                author,
+                repo,
+                tag,
+                "win",
+                &tag[1..],
+            )
+        }
+        OS::Linux => {
+            format!(
+                "https://github.com/{}/{}/releases/download/{}/BepInEx_{}_x64_{}.zip",
+                author,
+                repo,
+                tag,
+                "linux",
+                &tag[1..],
+            )
+        }
+        OS::MacOs => {
+            format!(
+                "https://github.com/{}/{}/releases/download/{}/BepInEx_{}_x64_{}.zip",
+                author,
+                repo,
+                tag,
+                "macos",
+                &tag[1..],
+            )
+        }
+    }
+}
+
+fn update_launch_script(game_path: &Path, exe_name: &str) -> Result<(), Box<dyn Error>> {
+    let launch_script_name = "run_bepinex.sh";
+
+    let launch_script_path = game_path.join(launch_script_name);
+    match launch_script_path.exists() {
+        true => {
+            let mut script = String::new();
+            let mut file = fs::File::open(&launch_script_path)?;
+
+            file.read_to_string(&mut script)?;
+
+            let updated_script = script.replace(
+                r#"executable_name="""#,
+                &format!(r#"executable_name="{}""#, &exe_name),
+            );
+
+            let mut file = fs::File::create(&launch_script_path)?;
+            file.write_all(updated_script.as_bytes())?;
+        }
+        false => return Err("Could not find the BepInEx launch script!".into()),
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_check_installation_windows() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let bepinex_dir = game_path.join("BepInEx");
+        fs::create_dir_all(bepinex_dir.join("core")).unwrap();
+        File::create(game_path.join("doorstop_config.ini")).unwrap();
+        File::create(game_path.join("winhttp.dll")).unwrap();
+        File::create(game_path.join(".doorstop_version")).unwrap();
+        File::create(game_path.join("changelog.txt")).unwrap();
+
+        let provider = WindowsBepinexProvider { game_path };
+
+        let result = provider.check_installation();
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_check_installation_linux() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let bepinex_dir = game_path.join("BepInEx");
+        fs::create_dir_all(bepinex_dir.join("core")).unwrap();
+        File::create(game_path.join("libdoorstop.so")).unwrap();
+        File::create(game_path.join("run_bepinex.sh")).unwrap();
+        File::create(game_path.join(".doorstop_version")).unwrap();
+        File::create(game_path.join("changelog.txt")).unwrap();
+
+        let provider = LinuxBepinexProvider { game_path };
+
+        let result = provider.check_installation();
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_check_installation_macos() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let bepinex_dir = game_path.join("BepInEx");
+        fs::create_dir_all(bepinex_dir.join("core")).unwrap();
+        File::create(game_path.join("libdoorstop.dylib")).unwrap();
+        File::create(game_path.join("run_bepinex.sh")).unwrap();
+        File::create(game_path.join(".doorstop_version")).unwrap();
+        File::create(game_path.join("changelog.txt")).unwrap();
+
+        let provider = MacOSBepinexProvider { game_path };
+
+        let result = provider.check_installation();
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_check_installation_failed_linux() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let provider = LinuxBepinexProvider { game_path };
+
+        let result = provider.check_installation();
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_check_installation_failed_windows() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let provider = WindowsBepinexProvider { game_path };
+
+        let result = provider.check_installation();
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_check_installation_failed_macos() {
+        let temp_dir = tempdir().unwrap();
+        let game_path = temp_dir.path().to_path_buf();
+
+        let provider = MacOSBepinexProvider { game_path };
+
+        let result = provider.check_installation();
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+}

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -151,10 +151,14 @@ mod tests {
         };
         let detector = Detector::new(provider);
 
-        std::env::set_var("ABYSS_GAME_DIR", dir.path());
+        unsafe {
+            std::env::set_var("ABYSS_GAME_DIR", dir.path());
+        }
         let got = detector.detect_game_dir(None, None, &[]).unwrap();
         assert_eq!(got, dir.path());
-        std::env::remove_var("ABYSS_GAME_DIR");
+        unsafe {
+            std::env::remove_var("ABYSS_GAME_DIR");
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bepinex_provider;
 pub mod detector;
 pub mod provider;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,14 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use tracing::{Level, error, info};
-use tracing_subscriber;
+mod bepinex_handler;
+mod bepinex_provider;
 mod detector;
 mod provider;
 use detector::Detector;
 use provider::RealSteamProvider;
+
+use crate::bepinex_handler::BepinexHandler;
 
 // SILKSONG_APP_ID is available from the library crate root
 
@@ -43,6 +46,35 @@ enum Commands {
         #[arg(long)]
         quiet: bool,
     },
+
+    /// Checks if BepInEx is installed
+    Check {
+        /// Manual override of the game directory (highest precedence)
+        #[arg(long, value_name = "PATH")]
+        game_dir: Option<PathBuf>,
+
+        /// Optional Steam AppID (for debugging)
+        #[arg(long, value_name = "APPID")]
+        app_id: Option<u32>,
+
+        /// Extra folder name hints to search under steamapps/common
+        #[arg(long = "name-hint", value_name = "NAME", num_args = 0.., action = clap::ArgAction::Append)]
+        name_hints: Vec<String>,
+    },
+
+    Install {
+        /// Manual override of the game directory (highest precedence)
+        #[arg(long, value_name = "PATH")]
+        game_dir: Option<PathBuf>,
+
+        /// Optional Steam AppID (for debugging)
+        #[arg(long, value_name = "APPID")]
+        app_id: Option<u32>,
+
+        /// Extra folder name hints to search under steamapps/common
+        #[arg(long = "name-hint", value_name = "NAME", num_args = 0.., action = clap::ArgAction::Append)]
+        name_hints: Vec<String>,
+    },
 }
 
 fn main() {
@@ -68,6 +100,59 @@ fn main() {
                     }
                     info!("Game directory detected: {}", path.display());
                 }
+                Err(err) => {
+                    error!("{err:#}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        Commands::Check {
+            game_dir,
+            app_id,
+            name_hints,
+        } => {
+            println!("TODO: check command");
+            let detector = Detector::new(RealSteamProvider);
+
+            let game_path = match detector.detect_game_dir(game_dir.as_deref(), app_id, &name_hints)
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    error!("{err:#}");
+                    std::process::exit(1);
+                }
+            };
+
+            let handler = BepinexHandler::new(game_path);
+            match handler.check_installation() {
+                Ok(true) => println!("BepInEx installation found"),
+                Ok(false) => println!(
+                    "BepInEx installation not found, you can install it with 'abyss install'"
+                ),
+                Err(err) => {
+                    error!("{err:#}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        Commands::Install {
+            game_dir,
+            app_id,
+            name_hints,
+        } => {
+            let detector = Detector::new(RealSteamProvider);
+            let game_path = match detector.detect_game_dir(game_dir.as_deref(), app_id, &name_hints)
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    error!("{err:#}");
+                    std::process::exit(1);
+                }
+            };
+
+            let handler = BepinexHandler::new(game_path);
+            match handler.install() {
+                Ok(_) => println!("BepInEx successfully installed"),
                 Err(err) => {
                     error!("{err:#}");
                     std::process::exit(1);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,9 @@
+use abyss::bepinex_provider::{
+    BepinexProvider, LinuxBepinexProvider, MacOSBepinexProvider, WindowsBepinexProvider,
+};
 use abyss::detector::Detector;
 use abyss::provider::RealSteamProvider;
+use tempfile::tempdir;
 
 // Runs only when ENABLE_INTEGRATION_TESTS=1 is set in the environment
 #[test]
@@ -14,4 +18,37 @@ fn real_provider_integration() {
     let res = detector.detect_game_dir(None, None, &[]);
     println!("Integration result: {:?}", res);
     // We don't assert success, just ensure the call doesn't panic
+}
+
+#[test]
+fn bepinex_installation_integration_linux() {
+    let temp_dir = tempdir().unwrap();
+    let game_path = temp_dir.path().to_path_buf();
+
+    let provider = LinuxBepinexProvider { game_path };
+    provider.install().unwrap();
+
+    assert!(provider.check_installation().unwrap());
+}
+
+#[test]
+fn bepinex_installation_integration_windows() {
+    let temp_dir = tempdir().unwrap();
+    let game_path = temp_dir.path().to_path_buf();
+
+    let provider = WindowsBepinexProvider { game_path };
+    provider.install().unwrap();
+
+    assert!(provider.check_installation().unwrap());
+}
+
+#[test]
+fn bepinex_installation_integration_macos() {
+    let temp_dir = tempdir().unwrap();
+    let game_path = temp_dir.path().to_path_buf();
+
+    let provider = MacOSBepinexProvider { game_path };
+    provider.install().unwrap();
+
+    assert!(provider.check_installation().unwrap());
 }


### PR DESCRIPTION
# Added a check to see if BepInEx is installed and an installation feature
## Installation check

A BepinexHandler struct has been added to handle the check. When created, it initializes a provider based on the user's operating system (Windows, MacOS and Linux) that implements the specific instructions for that platform. The check is successful if the BepInEx/core directory and the 4 files at the root of the game directory are present.

This can be called via the ````abyss check```` command

## Installation of BepInEx

The BepinexHandler and the specific providers also implement the installation function. The tag for the latest release is fetched from the github api, it is then used to build the download url. The zip archive for the correct OS is downloaded and then extracted in the game's directory. Linux and MacOS providers also add the executable file's name to the run_bepinex.sh launch script. If BepInEx is already installed the user will be asked if they want to reinstall it or not.

This can be called with the ````abyss install```` command.


## Other small changes

- Added serde_json to the dependencies to parse the response from the github api
- Reverted the changes from commit 0eb6da2, it appears the unsafe blocks were necessary according to the compiler and documentation


I hope I did things right and that this contribution is helpful!